### PR TITLE
Feat, Fix: Modify select end date & Modify day props type

### DIFF
--- a/src/components/Calendar/CalendarWeek.tsx
+++ b/src/components/Calendar/CalendarWeek.tsx
@@ -37,7 +37,7 @@ const CalendarWeek = forwardRef<HTMLDivElement, CalendarWeekProps>(
     };
 
     const checkActive = (date: number) => {
-      if (!params.date) return;
+      if (!params.date) return false;
 
       return +params.date === date;
     };

--- a/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/src/components/DateTimePicker/DateTimePicker.tsx
@@ -25,6 +25,10 @@ const DateTimePicker: React.FC<DateTimePickerProps> = ({
     } else {
       setIsInvalidEndDate(false);
     }
+
+    if (startDate.getDate() < endDate.getDate()) {
+      setIsInvalidEndDate(true);
+    }
   };
 
   useEffect(() => {

--- a/src/components/Day/Day.types.ts
+++ b/src/components/Day/Day.types.ts
@@ -3,5 +3,5 @@ export type DayProps = {
   month: number;
   date: number;
   idx: number;
-  isActive: boolean | undefined;
+  isActive: boolean;
 };

--- a/src/components/TaskForm/AddTaskForm.tsx
+++ b/src/components/TaskForm/AddTaskForm.tsx
@@ -56,7 +56,9 @@ const AddTaskForm = () => {
 
   const handleAddTask = () => {
     if (isInvalid) {
-      alert('시작 날짜는 종료 날짜 이전이어야 합니다.');
+      alert(
+        '시작 날짜는 종료 날짜 이전이거나, 종료 날짜는 시작 날짜와 같아야 합니다.'
+      );
       return;
     }
 

--- a/src/components/TaskForm/EditTaskForm.tsx
+++ b/src/components/TaskForm/EditTaskForm.tsx
@@ -64,7 +64,9 @@ const EditTaskForm = () => {
 
   const handleAddTask = () => {
     if (isInvalid) {
-      alert('시작 날짜는 종료 날짜 이전이어야 합니다.');
+      alert(
+        '시작 날짜는 종료 날짜 이전이거나, 종료 날짜는 시작 날짜와 같아야 합니다.'
+      );
       return;
     }
 


### PR DESCRIPTION
### Type of Change
- [x] 새로운 기능
- [ ] 기능 관련 수정
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 그 외

### PR Detail
- DatePicker 종료일이 시작일의 일 보다 클 경우 등록하지 못하도록 함
- Day 컴포넌트의 isActive props 타입을 boolean 으로 변경
- CalendarWeek 컴포넌트의 checkActive 함수에서 파라미터 없을 때 false 반환

### 주의 사항 및 전달 사항
이러한 내용은 주의 하셔야하고, 이런 것은 추후 변경 예정입니다...