### PR TITLE
Feat: Add redux-persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-datepicker": "^4.8.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "^6.3.0"
+    "react-router-dom": "^6.3.0",
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.15",

--- a/src/components/Calendar/Calendar.styled.tsx
+++ b/src/components/Calendar/Calendar.styled.tsx
@@ -34,8 +34,11 @@ export const CalendarHeader = styled.div`
   padding: 0 1.6rem;
   padding-bottom: 2.1rem;
   color: var(--gray-08);
-
   ${Body01}
+
+  img {
+    cursor: pointer;
+  }
 
   @media (min-width: 768px) {
     ${Display01}

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,15 +1,7 @@
-/** @jsxImportSource @emotion/react */
 import React from 'react';
 import Day from '../Day/Day';
 import prevIcon from '../../assets/left-icon.svg';
 import nextIcon from '../../assets/right-icon.svg';
-import {
-  Body01,
-  Display01,
-  Display05,
-  Headline,
-} from '../../styles/typography';
-import { Pointer } from '../../styles/unit';
 import {
   CalendarContent,
   CalendarHeader,
@@ -18,7 +10,6 @@ import {
   DateHead,
 } from './Calendar.styled';
 import { CalendarProps } from './Calendar.types';
-import { css } from '@emotion/react';
 
 const Calendar: React.FC<CalendarProps> = ({
   year,
@@ -50,11 +41,11 @@ const Calendar: React.FC<CalendarProps> = ({
   return (
     <CalendarWrapper>
       <CalendarHeader>
-        <img src={prevIcon} onClick={handleGoPrevMonth} css={Pointer} />
+        <img src={prevIcon} onClick={handleGoPrevMonth} />
         <div>
           {year}.{month.toString().padStart(2, '0')}
         </div>
-        <img src={nextIcon} onClick={handleGoNextvMonth} css={Pointer} />
+        <img src={nextIcon} onClick={handleGoNextvMonth} />
       </CalendarHeader>
       <CalendarContent>
         <DateHead>

--- a/src/components/Calendar/CalendarWeek.tsx
+++ b/src/components/Calendar/CalendarWeek.tsx
@@ -1,17 +1,14 @@
-/** @jsxImportSource @emotion/react */
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { getDayStr } from '../../utils/dateUtil';
 
 import prevIcon from '../../assets/left-icon.svg';
 import nextIcon from '../../assets/right-icon.svg';
-import { Body01 } from '../../styles/typography';
 import Day from '../Day/Day';
 import { CalendarWeekProps } from './Calendar.types';
 import {
   CalendarHeader,
   CalendarWeekWrapper,
-  DateBoard,
   DateHead,
   WeekDateBoard,
 } from './Calendar.styled';
@@ -46,19 +43,11 @@ const CalendarWeek = forwardRef<HTMLDivElement, CalendarWeekProps>(
     return (
       <CalendarWeekWrapper ref={ref}>
         <CalendarHeader>
-          <img
-            src={prevIcon}
-            onClick={handleGoPrevMonth}
-            css={{ cursor: 'pointer' }}
-          />
+          <img src={prevIcon} onClick={handleGoPrevMonth} />
           <div>
             {year}.{month.toString().padStart(2, '0')}
           </div>
-          <img
-            src={nextIcon}
-            onClick={handleGoNextvMonth}
-            css={{ cursor: 'pointer' }}
-          />
+          <img src={nextIcon} onClick={handleGoNextvMonth} />
         </CalendarHeader>
         <div>
           <DateHead>

--- a/src/components/DateTimePicker/DateTimeInfo.tsx
+++ b/src/components/DateTimePicker/DateTimeInfo.tsx
@@ -1,5 +1,3 @@
-/** @jsxImportSource @emotion/react */
-import { css } from '@emotion/react';
 import { forwardRef } from 'react';
 import {
   DateTimeInfoWrapper,
@@ -14,20 +12,8 @@ const DateTimeInfo: React.FC<any> = forwardRef(
     const time = value.split('/')[1];
 
     return (
-      <DateTimeInfoWrapper
-        onClick={onClick}
-        ref={ref}
-        css={css`
-          ${isInvalid && 'text-decoration: line-through;'}
-        `}
-      >
-        <DateTitle
-          css={css`
-            ${isAllDay && 'font-weight: 700;'}
-          `}
-        >
-          {date}
-        </DateTitle>
+      <DateTimeInfoWrapper onClick={onClick} ref={ref} isInvalid={isInvalid}>
+        <DateTitle isAllDay={isAllDay}>{date}</DateTitle>
         {!isAllDay && <TimeTitle>{time}</TimeTitle>}
       </DateTimeInfoWrapper>
     );

--- a/src/components/DateTimePicker/DateTimePicker.styled.tsx
+++ b/src/components/DateTimePicker/DateTimePicker.styled.tsx
@@ -19,14 +19,17 @@ export const DateTimePickerWrapper = styled.div`
   }
 `;
 
-export const DateTimeInfoWrapper = styled.div`
+export const DateTimeInfoWrapper = styled.div<{ isInvalid: boolean }>`
   text-align: center;
   cursor: pointer;
+
+  ${(props) => props.isInvalid && 'text-decoration: line-through;'}
 `;
 
-export const DateTitle = styled.div`
+export const DateTitle = styled.div<{ isAllDay: boolean }>`
   ${Body01}
   color: var(--gray-08);
+  ${(props) => props.isAllDay && 'font-weight: 700;'}
 
   @media (min-width: 768px) {
     font-size: 2rem;

--- a/src/components/Day/Day.tsx
+++ b/src/components/Day/Day.tsx
@@ -12,11 +12,19 @@ import { DayProps } from './Day.types';
 
 const Day: React.FC<DayProps> = ({ year, month, date, idx, isActive }) => {
   const navigate = useNavigate();
-  const taskList = useSelector((state: RootState) => state.task.items).filter(
-    (task) =>
-      task.startDate.getFullYear() === year &&
-      task.startDate.getMonth() + 1 === month
-  );
+  const taskList = useSelector((state: RootState) => state.taskSlice.items)
+    .map((task) => {
+      return {
+        ...task,
+        startDate: new Date(task.startDate),
+        endDate: new Date(task.endDate),
+      };
+    })
+    .filter(
+      (task) =>
+        task.startDate.getFullYear() === year &&
+        task.startDate.getMonth() + 1 === month
+    );
   const lastDay = new Date(year, month, 0).getDate(); // 현재 월의 마지막 날 구하기
   const filterdTaskList = taskList.filter(
     (task) => task.startDate.getDate() === date + idx

--- a/src/components/Day/Day.tsx
+++ b/src/components/Day/Day.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router';
 import { RootState } from '../../store';

--- a/src/components/Task/Task.tsx
+++ b/src/components/Task/Task.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @emotion/react */
 import { format } from 'date-fns';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -48,7 +49,7 @@ const Task: React.FC<taskProps> = ({ task }) => {
         </TaskContent>
       </TaskInfoWrapper>
 
-      <div style={{ position: 'relative' }}>
+      <div css={{ position: 'relative' }}>
         <TaskMoreIcon
           src={moreIcon}
           alt="더보기"

--- a/src/components/TaskForm/EditTaskForm.tsx
+++ b/src/components/TaskForm/EditTaskForm.tsx
@@ -39,7 +39,15 @@ const EditTaskForm = () => {
   const navigate = useNavigate();
   const params = useParams();
 
-  const taskList = useSelector((state: RootState) => state.task.items);
+  const taskList = useSelector((state: RootState) => state.taskSlice.items).map(
+    (task) => {
+      return {
+        ...task,
+        startDate: new Date(task.startDate),
+        endDate: new Date(task.endDate),
+      };
+    }
+  );
 
   useEffect(() => {
     const taskId = params.taskId;

--- a/src/components/TaskList/TaskList.tsx
+++ b/src/components/TaskList/TaskList.tsx
@@ -16,11 +16,19 @@ import { forwardRef, useEffect, useRef } from 'react';
 
 const TaskList = forwardRef<HTMLDivElement, TaskListProps>(
   ({ year, month, date }, ref) => {
-    const taskList = useSelector((state: RootState) => state.task.items).filter(
-      (task) =>
-        task.startDate.getFullYear() === year &&
-        task.startDate.getMonth() + 1 === month
-    );
+    const taskList = useSelector((state: RootState) => state.taskSlice.items)
+      .map((task) => {
+        return {
+          ...task,
+          startDate: new Date(task.startDate),
+          endDate: new Date(task.endDate),
+        };
+      })
+      .filter(
+        (task) =>
+          task.startDate.getFullYear() === year &&
+          task.startDate.getMonth() + 1 === month
+      );
 
     const dateRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<HTMLDivElement>(null);

--- a/src/components/UI/Toggle.tsx
+++ b/src/components/UI/Toggle.tsx
@@ -1,4 +1,3 @@
-/** @jsxImportSource @emotion/react */
 import { ToggleLabel, Active } from './Toggle.styled';
 import { ToggleProps } from './Toggle.types';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,18 +2,23 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Global } from '@emotion/react';
 import { BrowserRouter } from 'react-router-dom';
+import { persistStore } from 'redux-persist';
+import { PersistGate } from 'redux-persist/integration/react';
 
 import App from './App';
 import { global } from './styles/global';
 import { Provider } from 'react-redux';
 import store from './store';
+const persistor = persistStore(store);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <Provider store={store}>
-        <Global styles={global} />
-        <App />
+        <PersistGate persistor={persistor}>
+          <Global styles={global} />
+          <App />
+        </PersistGate>
       </Provider>
     </BrowserRouter>
   </React.StrictMode>

--- a/src/pages/MonthCalendar.tsx
+++ b/src/pages/MonthCalendar.tsx
@@ -1,4 +1,3 @@
-/** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
 import { useState } from 'react';
 import Calendar from '../components/Calendar/Calendar';

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,14 +1,27 @@
-import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers } from 'redux';
+import { persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 
 import taskSlice from './taskSlice';
 
+const persistConfig = {
+  key: 'root',
+  storage,
+};
+
+const rootReducer = combineReducers({
+  taskSlice,
+});
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
 const store = configureStore({
-  reducer: {
-    task: taskSlice.reducer,
-  },
-  middleware: getDefaultMiddleware({
-    serializableCheck: false,
-  }),
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/store/taskSlice.ts
+++ b/src/store/taskSlice.ts
@@ -111,4 +111,4 @@ const taskSlice = createSlice({
 
 export const taskActions = taskSlice.actions;
 
-export default taskSlice;
+export default taskSlice.reducer;


### PR DESCRIPTION
### Type of Change
- [x] 새로운 기능
- [ ] 기능 관련 수정
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 그 외

### PR Detail
- Redux-persist 적용
  - 할일 리스트 local storage 에 저장


### 주의 사항 및 전달 사항
현재 이 프로젝트의 redux-persist 는 local storage 에 저장하도록 설정되어있다.
local storage 는 string 타입만 저장이 가능한데, task는 startDate, endDate 와 같이 Date 타입인 변수가 존재한다.
useSelector 를 사용하여 state를 가져올 때 local storage에 string 타입으로 저장되었던 startDate, endDate 를 Date 타입으로 변환하는 작업이 필요하다.

**[예시]**
```javascript
const taskList = useSelector((state: RootState) => state.taskSlice.items)
  .map((task) => {
    return {
      ...task,
      startDate: new Date(task.startDate),
      endDate: new Date(task.endDate),
    };
  })
```